### PR TITLE
feat: レシピに紐づくtalkRoomIdで会話画面リンクを表示

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -3,18 +3,18 @@ generator client {
 }
 
 datasource db {
-  provider = "postgresql"
-  url      = env("DATABASE_URL")
+  provider  = "postgresql"
+  url       = env("DATABASE_URL")
   directUrl = env("DIRECT_URL")
 }
 
 // ユーザーテーブル
 model User {
-  id             Int        @id @default(autoincrement())
+  id             Int                  @id @default(autoincrement())
   name           String
-  supabaseUserId String     @unique
-  createdAt      DateTime   @default(now())
-  updatedAt      DateTime   @updatedAt
+  supabaseUserId String               @unique
+  createdAt      DateTime             @default(now())
+  updatedAt      DateTime             @updatedAt
   talkRoom       TalkRoom?
   talkKeywords   TalkKeyword[]
   recipes        Recipe[]
@@ -52,6 +52,7 @@ model TalkRoom {
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
   user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  recipes   Recipe[]
 }
 
 // チャット入力補助ワードテーブル
@@ -67,6 +68,7 @@ model TalkKeyword {
   createdAt         DateTime  @default(now())
   updatedAt         DateTime  @updatedAt
   user              User?     @relation(fields: [userId], references: [id])
+
   @@unique([userId, normalizedKeyword])
   @@index([userId, usageCount(sort: Desc)])
   @@index([userId, lastUsedAt(sort: Desc)])
@@ -74,7 +76,7 @@ model TalkKeyword {
 
 // レシピテーブル
 model Recipe {
-  id            Int             @id @default(autoincrement())
+  id            Int                  @id @default(autoincrement())
   title         String
   point         String?
   cookingTime   String?
@@ -84,9 +86,11 @@ model Recipe {
   tags          RecipeTagRelation[]
   favorites     UserFavoriteRecipe[]
   createdByUser Int
-  createdAt     DateTime        @default(now())
-  updatedAt     DateTime        @updatedAt
-  user          User            @relation(fields: [createdByUser], references: [id])
+  createdAt     DateTime             @default(now())
+  updatedAt     DateTime             @updatedAt
+  talkRoomId    Int
+  user          User                 @relation(fields: [createdByUser], references: [id])
+  talkRoom      TalkRoom             @relation(fields: [talkRoomId], references: [id])
 }
 
 // レシピ表示用タグテーブル
@@ -94,6 +98,7 @@ model RecipeTag {
   id      Int                 @id @default(autoincrement())
   tag     String
   recipes RecipeTagRelation[]
+
   @@unique([tag])
 }
 
@@ -106,6 +111,7 @@ model RecipeTagRelation {
   updatedAt DateTime  @updatedAt
   recipe    Recipe    @relation(fields: [recipeId], references: [id])
   tag       RecipeTag @relation(fields: [tagId], references: [id])
+
   @@unique([recipeId, tagId])
 }
 

--- a/src/app/(authenticated)/recipes/[recipeId]/page.tsx
+++ b/src/app/(authenticated)/recipes/[recipeId]/page.tsx
@@ -2,15 +2,15 @@
 
 import { numberSchema } from '@/lib/schema/numberSchema';
 import { recipeDetailSchema } from '@/lib/schema/recipeSchema';
-import { userRoomSchema } from '@auth/lib/validation/userRoomSchema';
 import { Loading } from '@authenticated/components/Loading';
-import { useAuthedSWR } from '@authenticated/hooks/useAuthedSWR';
 import { useRecipes } from '@authenticated/hooks/useRecipes';
 import { RecipeItem } from '@authenticated/recipes/components/RecipeItem';
 import Link from 'next/link';
-import { useParams } from 'next/navigation';
+import { useParams, useRouter } from 'next/navigation';
 
 export default function RecipeDetailPage() {
+  const router = useRouter();
+
   const params = useParams();
   const parsedParams = numberSchema.safeParse(params.recipeId);
   if (!parsedParams.success) return <p>不正なURLです</p>;
@@ -20,42 +20,42 @@ export default function RecipeDetailPage() {
   const {
     data: recipe,
     error: recipeError,
-    isLoading: isRecipsLoading,
+    isLoading: isRecipeLoading,
   } = useRecipes(`/api/recipes/${recipeId}`, recipeDetailSchema);
-
-  const { data: userRoom } = useAuthedSWR('/api/userRoom', userRoomSchema);
-  if (!userRoom) return <Loading />;
-
-  const talkRoomId = userRoom.talkRoom.id;
 
   if (recipeError) {
     return (
-      <div>
+      <>
         <p>{recipeError}</p>
-        <Link href="/recipes" className="text-sm underline">
-          レシピ一覧に戻る
-        </Link>
-        <Link href={`/talkRoom/${talkRoomId}`} className="text-sm underline">
-          会話に戻る
-        </Link>
-      </div>
+        <button onClick={() => router.back()}>戻る</button>
+        <Link href="/recipes">レシピ一覧に戻る</Link>
+      </>
     );
   }
 
-  if (!recipe) {
+  if (isRecipeLoading || !recipe) {
     return <Loading />;
   }
 
+  const talkRoomId = recipe.talkRoomId;
+
   return (
     <main className="p-6">
-      <h1 className="text-2xl font-bold mb-2">{recipe.title}</h1>
+      <h1 className="mb-2 text-2xl font-bold">{recipe.title}</h1>
+
       <RecipeItem recipe={recipe} />
+
       <Link href={`/recipes`} className="text-sm underline">
         すべてのレシピを見る
       </Link>
-      <Link href={`/talkRoom/${talkRoomId}`} className="text-sm underline">
-        会話に戻る
-      </Link>
+
+      {talkRoomId && (
+        <div className="mt-6">
+          <Link href={`/talkRoom/${talkRoomId}`} className="text-sm underline">
+            会話に戻る
+          </Link>
+        </div>
+      )}
     </main>
   );
 }

--- a/src/app/(authenticated)/recipes/page.tsx
+++ b/src/app/(authenticated)/recipes/page.tsx
@@ -1,10 +1,8 @@
 'use client';
 
 import { recipeSummaryListSchema } from '@/lib/schema/recipeSchema';
-import { userRoomSchema } from '@auth/lib/validation/userRoomSchema';
 import { Loading } from '@authenticated/components/Loading';
 
-import { useAuthedSWR } from '@authenticated/hooks/useAuthedSWR';
 import { useRecipes } from '@authenticated/hooks/useRecipes';
 import { RecipeList } from '@authenticated/recipes/components/RecipeList';
 import Link from 'next/link';
@@ -12,45 +10,54 @@ import { useRouter } from 'next/navigation';
 
 export default function RecipesPage() {
   const router = useRouter();
+
   const {
     data: recipes,
-    error: recipeError,
+    error: recipesError,
     isLoading: isRecipsLoading,
   } = useRecipes(`/api/recipes`, recipeSummaryListSchema);
 
-  const { data: userRoom } = useAuthedSWR('/api/userRoom', userRoomSchema);
-  if (!userRoom) return <Loading />;
-
-  const talkRoomId = userRoom.talkRoom.id;
-  // TODO: 複数room/共有機能/URL直アクセスに対応する場合、roomIdをURLから取得、API側で認可チェック（/api/talkRoom/[id]）を作成する
-
-  if (recipeError) {
-    <div>
-      <p>{recipeError}</p>
-      <button onClick={() => router.back()}>戻る</button>
-      <Link href="/">TOPに戻る</Link>
-    </div>;
+  if (recipesError) {
+    return (
+      <>
+        <p>{recipesError}</p>
+        <button onClick={() => router.back()}>戻る</button>
+        <Link href="/">TOPに戻る</Link>
+      </>
+    );
   }
 
   const renderRecipeList = () => {
-    if (!recipes) {
+    if (isRecipsLoading || !recipes) {
       return <Loading />;
     }
+
     if (recipes.length === 0) {
       return <p>レシピがまだありません</p>;
     }
+
     return <RecipeList recipes={recipes} cookingTime={true} />;
   };
 
+  // renderRecipeList内ガードの外なので、recipesが未取得でも落ちないようにする
+  const talkRoomId = recipes?.[0]?.talkRoomId;
+  // TODO: 複数room/共有機能/URL直アクセスに対応する場合、roomIdをURLparamsから取得、API側（/api/talkRoom/[id]）で認可チェックを行う
+
   return (
-    <>
-      <main className="mx-auto max-w-3xl p-6">
-        <h1 className="mb-6 text-2xl font-bold">あなたのレシピ一覧</h1>
-        {renderRecipeList()}
-        <Link href={`/talkRoom/${talkRoomId}`} className="text-sm underline">
-          会話に戻る
-        </Link>
-      </main>
-    </>
+    <main className="mx-auto max-w-3xl p-6">
+      <h1 className="mb-6 text-2xl font-bold">あなたのレシピ一覧</h1>
+
+      {/* 側は出つつ、中身だけ出し分け */}
+      {renderRecipeList()}
+
+      {/* ちらつき防止 */}
+      {talkRoomId && (
+        <div className="mt-6">
+          <Link href={`/talkRoom/${talkRoomId}`} className="text-sm underline">
+            会話に戻る
+          </Link>
+        </div>
+      )}
+    </main>
   );
 }

--- a/src/app/api/recipes/[id]/route.ts
+++ b/src/app/api/recipes/[id]/route.ts
@@ -27,7 +27,7 @@ export async function GET(
         ingredients: true,
         instructions: true,
         imageKey: true,
-        createdAt: true,
+        talkRoomId: true,
       },
     });
 

--- a/src/app/api/recipes/route.ts
+++ b/src/app/api/recipes/route.ts
@@ -22,6 +22,7 @@ export async function GET(request: NextRequest) {
         id: true,
         title: true,
         cookingTime: true,
+        talkRoomId: true,
       },
       orderBy: { createdAt: 'desc' },
       take,

--- a/src/app/api/talks/route.ts
+++ b/src/app/api/talks/route.ts
@@ -94,6 +94,7 @@ export async function POST(request: NextRequest) {
             ingredients: JSON.stringify(recipeObj['材料（2人分）']),
             instructions: JSON.stringify(recipeObj['作り方']),
             createdByUser: userId,
+            talkRoomId,
           },
         });
       }

--- a/src/lib/schema/recipeSchema.ts
+++ b/src/lib/schema/recipeSchema.ts
@@ -9,6 +9,7 @@ export type RecipeBaseList = z.infer<typeof recipeSchema>;
 
 export const recipeSummarySchema = recipeBaseSchema.extend({
   cookingTime: z.string().optional(),
+  talkRoomId: z.number(),
 });
 export const recipeSummaryListSchema = z.array(recipeSummarySchema);
 export type RecipeSummaryList = z.infer<typeof recipeSummaryListSchema>;
@@ -19,6 +20,7 @@ export const recipeDetailSchema = recipeBaseSchema.extend({
   ingredients: z.string(),
   instructions: z.string(),
   imageKey: z.string().nullable().optional(),
+  talkRoomId: z.number(),
 });
 export type RecipeDetail = z.infer<typeof recipeDetailSchema>;
 


### PR DESCRIPTION
## 対応内容
レシピを経由する画面向けに、talkRoomIdをリレーションから取得
- レシピ作成時にtalkRoomIdを保存
- レシピ一覧API・レシピ詳細APIでtalkRoomIdを返却
- schema定義にtalkRoomIdを追加
- レシピ一覧・レシピ詳細でrecipeのtalkRoomIdから会話に戻るリンクを表示

## 補足
- レシピを経由しない共通UIでのtalkRoomId取得用に、userRoom APIは引き続き利用する予定

## 対象外
- レシピ一覧・レシピ詳細画面の本格UI反映