### PR TITLE
refactor: アイコン表示用Wrapperを追加

### DIFF
--- a/src/app/(authenticated)/_components/side/SideNav.tsx
+++ b/src/app/(authenticated)/_components/side/SideNav.tsx
@@ -1,9 +1,9 @@
 import { userRoomSchema } from '@auth/lib/validation/userRoomSchema';
 import { Loading } from '@authenticated/components/Loading';
 import { useAuthedSWR } from '@authenticated/hooks/useAuthedSWR';
-import Image from 'next/image';
 import { ReactNode } from 'react';
 import { Button } from '../../../../components/ui/Button';
+import { IconImage } from '../../../../components/ui/IconImage';
 import { IconWrapper } from '../../../../components/ui/IconWrapper';
 
 type Props = {
@@ -36,13 +36,11 @@ export const SideNav = ({ children }: Props) => {
         <li>
           <Button href={`/talkRoom/${talkRoomId}`} variant="side-chat">
             <IconWrapper>
-              <Image
+              <IconImage
                 src="/icons/system/chat.svg"
-                alt=""
-                aria-hidden="true"
                 width={18}
                 height={18}
-                className="size-[18px] shrink-0"
+                className="size-[18px]"
               />
             </IconWrapper>
             <span>Chat</span>
@@ -51,13 +49,11 @@ export const SideNav = ({ children }: Props) => {
         <li>
           <Button href="/mypage" variant="side-mypage">
             <IconWrapper>
-              <Image
+              <IconImage
                 src="/icons/system/account.svg"
-                alt=""
-                aria-hidden="true"
                 width={22}
                 height={22}
-                className="h-auto shrink-0"
+                className="h-auto"
               />
             </IconWrapper>
             <span>MYページ</span>
@@ -66,13 +62,11 @@ export const SideNav = ({ children }: Props) => {
         <li>
           <Button href="/recipes" variant="side-my-recipes">
             <IconWrapper>
-              <Image
+              <IconImage
                 src="/icons/system/recipe.svg"
-                alt=""
-                aria-hidden="true"
                 width={15}
                 height={15}
-                className="size-[15px] shrink-0"
+                className="size-[15px]"
               />
             </IconWrapper>
             <span>MYレシピ</span>

--- a/src/app/(authenticated)/_components/side/SideNav.tsx
+++ b/src/app/(authenticated)/_components/side/SideNav.tsx
@@ -3,8 +3,8 @@ import { Loading } from '@authenticated/components/Loading';
 import { useAuthedSWR } from '@authenticated/hooks/useAuthedSWR';
 import { ReactNode } from 'react';
 import { Button } from '../../../../components/ui/Button';
-import { IconImage } from '../../../../components/ui/IconImage';
 import { IconWrapper } from '../../../../components/ui/IconWrapper';
+import { NavImage } from '../../../../components/ui/NavImage';
 
 type Props = {
   children?: ReactNode;
@@ -36,7 +36,7 @@ export const SideNav = ({ children }: Props) => {
         <li>
           <Button href={`/talkRoom/${talkRoomId}`} variant="side-chat">
             <IconWrapper>
-              <IconImage
+              <NavImage
                 src="/icons/system/chat.svg"
                 width={18}
                 height={18}
@@ -49,7 +49,7 @@ export const SideNav = ({ children }: Props) => {
         <li>
           <Button href="/mypage" variant="side-mypage">
             <IconWrapper>
-              <IconImage
+              <NavImage
                 src="/icons/system/account.svg"
                 width={22}
                 height={22}
@@ -62,7 +62,7 @@ export const SideNav = ({ children }: Props) => {
         <li>
           <Button href="/recipes" variant="side-my-recipes">
             <IconWrapper>
-              <IconImage
+              <NavImage
                 src="/icons/system/recipe.svg"
                 width={15}
                 height={15}

--- a/src/app/(authenticated)/_components/side/SideNav.tsx
+++ b/src/app/(authenticated)/_components/side/SideNav.tsx
@@ -4,6 +4,7 @@ import { useAuthedSWR } from '@authenticated/hooks/useAuthedSWR';
 import Image from 'next/image';
 import { ReactNode } from 'react';
 import { Button } from '../../../../components/ui/Button';
+import { IconWrapper } from '../../../../components/ui/IconWrapper';
 
 type Props = {
   children?: ReactNode;
@@ -34,7 +35,7 @@ export const SideNav = ({ children }: Props) => {
       <ul className="mb-8 flex flex-col gap-4 pt-4">
         <li>
           <Button href={`/talkRoom/${talkRoomId}`} variant="side-chat">
-            <div className="flex w-[24px] shrink-0 justify-center">
+            <IconWrapper>
               <Image
                 src="/icons/system/chat.svg"
                 alt=""
@@ -43,13 +44,13 @@ export const SideNav = ({ children }: Props) => {
                 height={18}
                 className="size-[18px] shrink-0"
               />
-            </div>
+            </IconWrapper>
             <span>Chat</span>
           </Button>
         </li>
         <li>
           <Button href="/mypage" variant="side-mypage">
-            <div className="flex w-[24px] shrink-0 justify-center">
+            <IconWrapper>
               <Image
                 src="/icons/system/account.svg"
                 alt=""
@@ -58,13 +59,13 @@ export const SideNav = ({ children }: Props) => {
                 height={22}
                 className="h-auto shrink-0"
               />
-            </div>
+            </IconWrapper>
             <span>MYページ</span>
           </Button>
         </li>
         <li>
           <Button href="/recipes" variant="side-my-recipes">
-            <div className="flex w-[24px] shrink-0 justify-center">
+            <IconWrapper>
               <Image
                 src="/icons/system/recipe.svg"
                 alt=""
@@ -73,7 +74,7 @@ export const SideNav = ({ children }: Props) => {
                 height={15}
                 className="size-[15px] shrink-0"
               />
-            </div>
+            </IconWrapper>
             <span>MYレシピ</span>
           </Button>
         </li>

--- a/src/components/ui/IconImage.tsx
+++ b/src/components/ui/IconImage.tsx
@@ -1,0 +1,22 @@
+import { cn } from '@/lib/utils/cn';
+import Image from 'next/image';
+
+type Props = {
+  src: string;
+  width: number;
+  height: number;
+  className?: string;
+};
+
+export const IconImage = ({ src, width, height, className }: Props) => {
+  return (
+    <Image
+      src={src}
+      alt=""
+      aria-hidden="true"
+      width={width}
+      height={height}
+      className={cn('shrink-0', className)}
+    />
+  );
+};

--- a/src/components/ui/IconWrapper.tsx
+++ b/src/components/ui/IconWrapper.tsx
@@ -1,0 +1,9 @@
+type Props = {
+  children: React.ReactNode;
+};
+
+export const IconWrapper = ({ children }: Props) => {
+  return (
+    <div className="flex w-[24px] shrink-0 justify-center">{children}</div>
+  );
+};

--- a/src/components/ui/NavImage.tsx
+++ b/src/components/ui/NavImage.tsx
@@ -8,7 +8,7 @@ type Props = {
   className?: string;
 };
 
-export const IconImage = ({ src, width, height, className }: Props) => {
+export const NavImage = ({ src, width, height, className }: Props) => {
   return (
     <Image
       src={src}


### PR DESCRIPTION
## 対応内容
Buttonでアイコンを扱う箇所が増えるため、表示枠を共通化しました。
- アイコン幅と中央揃えのスタイルをIconWrapperに集約
- アイコン画像表示用のIconImageを追加