### PR TITLE
refactor: レシピ画面のUI土台を整理

### DIFF
--- a/src/app/(authenticated)/_components/side/SideNav.tsx
+++ b/src/app/(authenticated)/_components/side/SideNav.tsx
@@ -3,8 +3,8 @@ import { Loading } from '@authenticated/components/Loading';
 import { useAuthedSWR } from '@authenticated/hooks/useAuthedSWR';
 import { ReactNode } from 'react';
 import { Button } from '../../../../components/ui/Button';
+import { Icon } from '../../../../components/ui/Icon';
 import { IconWrapper } from '../../../../components/ui/IconWrapper';
-import { NavImage } from '../../../../components/ui/NavImage';
 
 type Props = {
   children?: ReactNode;
@@ -36,7 +36,7 @@ export const SideNav = ({ children }: Props) => {
         <li>
           <Button href={`/talkRoom/${talkRoomId}`} variant="side-chat">
             <IconWrapper>
-              <NavImage
+              <Icon
                 src="/icons/system/chat.svg"
                 width={18}
                 height={18}
@@ -49,7 +49,7 @@ export const SideNav = ({ children }: Props) => {
         <li>
           <Button href="/mypage" variant="side-mypage">
             <IconWrapper>
-              <NavImage
+              <Icon
                 src="/icons/system/account.svg"
                 width={22}
                 height={22}
@@ -62,7 +62,7 @@ export const SideNav = ({ children }: Props) => {
         <li>
           <Button href="/recipes" variant="side-my-recipes">
             <IconWrapper>
-              <NavImage
+              <Icon
                 src="/icons/system/recipe.svg"
                 width={15}
                 height={15}

--- a/src/app/(authenticated)/_components/side/SideNav.tsx
+++ b/src/app/(authenticated)/_components/side/SideNav.tsx
@@ -10,6 +10,8 @@ type Props = {
   children?: ReactNode;
 };
 
+// NOTE: ログイン後画面で共通利用するサイドナビ
+// SideAreaはサイドバー外枠、SideNavは共通ナビ本体。childrenには画面ごとの追加要素を渡す。
 export const SideNav = ({ children }: Props) => {
   const {
     data: userRoom,
@@ -17,11 +19,14 @@ export const SideNav = ({ children }: Props) => {
     error,
   } = useAuthedSWR('/api/userRoom', userRoomSchema);
 
-  if (isLoading) return <Loading />;
-
   const talkRoomId = userRoom?.talkRoom.id;
 
-  // NOTE: talkRoomIdを取得できなかった場合のみ、失敗表示（ログイン済み前提、未ログイン状態は上位で認証ガード済）
+  // NOTE: userRoom取得中のundefinedを失敗扱いにしない
+  if (isLoading || !userRoom) {
+    return <Loading />;
+  }
+
+  // 認証済み前提でroomIdを取得できなかった場合のみ失敗表示
   if (error || !talkRoomId) {
     return (
       <nav>

--- a/src/app/(authenticated)/_components/side/SideNav.tsx
+++ b/src/app/(authenticated)/_components/side/SideNav.tsx
@@ -10,8 +10,8 @@ type Props = {
   children?: ReactNode;
 };
 
-// NOTE: ログイン後画面で共通利用するサイドナビ
-// SideAreaはサイドバー外枠、SideNavは共通ナビ本体。childrenには画面ごとの追加要素を渡す。
+// ログイン後画面で共通利用するサイドナビ
+// SideArea：サイドバー外枠、SideNav：共通ナビ本体。childrenには画面ごとの追加要素を渡す
 export const SideNav = ({ children }: Props) => {
   const {
     data: userRoom,
@@ -19,14 +19,13 @@ export const SideNav = ({ children }: Props) => {
     error,
   } = useAuthedSWR('/api/userRoom', userRoomSchema);
 
-  const talkRoomId = userRoom?.talkRoom.id;
-
-  // NOTE: userRoom取得中のundefinedを失敗扱いにしない
-  if (isLoading || !userRoom) {
+  if (isLoading) {
     return <Loading />;
   }
 
-  // 認証済み前提でroomIdを取得できなかった場合のみ失敗表示
+  const talkRoomId = userRoom?.talkRoom.id;
+
+  // 取得中undefinedはLoading、取得後undefinedは失敗表示
   if (error || !talkRoomId) {
     return (
       <nav>

--- a/src/app/(authenticated)/recipes/[recipeId]/page.tsx
+++ b/src/app/(authenticated)/recipes/[recipeId]/page.tsx
@@ -1,61 +1,118 @@
 'use client';
 
-import { numberSchema } from '@/lib/schema/numberSchema';
-import { recipeDetailSchema } from '@/lib/schema/recipeSchema';
+import { idParamSchema } from '@/lib/schema/paramSchema';
+import { recipeDetailSchema, recipeSchema } from '@/lib/schema/recipeSchema';
 import { Loading } from '@authenticated/components/Loading';
+import { SideArea } from '@authenticated/components/side/SideArea';
+import { SideNav } from '@authenticated/components/side/SideNav';
 import { useRecipes } from '@authenticated/hooks/useRecipes';
 import { RecipeItem } from '@authenticated/recipes/components/RecipeItem';
+import { SideRecipeList } from '@authenticated/talkRoom/components/side/SideRecipeList';
 import Link from 'next/link';
 import { useParams, useRouter } from 'next/navigation';
+import { Surface } from '../../../../components/ui/Surface';
 
 export default function RecipeDetailPage() {
   const router = useRouter();
-
   const params = useParams();
-  const parsedParams = numberSchema.safeParse(params.recipeId);
-  if (!parsedParams.success) return <p>不正なURLです</p>;
+
+  const parsedParams = idParamSchema.safeParse(params.recipeId);
+
+  if (!parsedParams.success) {
+    return (
+      <main className="px-4">
+        <p>不正なURLです</p>
+      </main>
+    );
+  }
 
   const recipeId = parsedParams.data;
 
+  const recipeListUrl = `/api/recipes?take=5`;
+  const recipeDetailUrl = `/api/recipes/${recipeId}`;
+
+  // サイドナビ用の最新レシピ一覧
+  const {
+    data: recipes,
+    error: recipesError,
+    isLoading: isRecipesLoading,
+  } = useRecipes(recipeListUrl, recipeSchema);
+
+  // レシピ詳細
   const {
     data: recipe,
     error: recipeError,
     isLoading: isRecipeLoading,
-  } = useRecipes(`/api/recipes/${recipeId}`, recipeDetailSchema);
+  } = useRecipes(recipeDetailUrl, recipeDetailSchema);
 
-  if (recipeError) {
+  const renderRecipeList = () => {
+    // NOTE: SideRecipeListは補助導線のため、取得失敗・未取得時は共通ナビのみ表示する
+    if (recipesError || !recipes || recipes.length === 0) {
+      return <SideNav />;
+    }
+
+    return (
+      <SideNav>
+        <SideRecipeList recipes={recipes} />
+      </SideNav>
+    );
+  };
+
+  const renderRecipeDetail = () => {
+    if (recipeError) {
+      return (
+        <>
+          <p>{recipeError}</p>
+          <button onClick={() => router.back()}>戻る</button>
+        </>
+      );
+    }
+
+    if (isRecipeLoading) {
+      return <Loading />;
+    }
+
+    if (!recipe) {
+      // NOTE: 通常はAPI側でエラーになる想定だが、data未取得の保険として表示
+      return (
+        <>
+          <p>レシピを表示できませんでした</p>
+          <button onClick={() => router.back()}>戻る</button>
+        </>
+      );
+    }
+
+    const talkRoomId = recipe.talkRoomId;
+
     return (
       <>
-        <p>{recipeError}</p>
-        <button onClick={() => router.back()}>戻る</button>
-        <Link href="/recipes">レシピ一覧に戻る</Link>
+        <Surface type="recipe-detail">
+          <RecipeItem recipe={recipe} />
+        </Surface>
+
+        {/* ちらつき防止 */}
+        {talkRoomId && (
+          <div className="mt-6">
+            <Link
+              href={`/talkRoom/${talkRoomId}`}
+              className="text-sm underline"
+            >
+              会話に戻る
+            </Link>
+          </div>
+        )}
       </>
     );
-  }
-
-  if (isRecipeLoading || !recipe) {
-    return <Loading />;
-  }
-
-  const talkRoomId = recipe.talkRoomId;
+  };
 
   return (
-    <main className="p-6">
-      <h1 className="mb-2 text-2xl font-bold">{recipe.title}</h1>
+    <div className="flex h-[calc(100vh-55px)] gap-8">
+      <SideArea>{renderRecipeList()}</SideArea>
 
-      <RecipeItem recipe={recipe} />
-
-      <Link href={`/recipes`} className="text-sm underline">
-        すべてのレシピを見る
-      </Link>
-
-      {talkRoomId && (
-        <div className="mt-6">
-          <Link href={`/talkRoom/${talkRoomId}`} className="text-sm underline">
-            会話に戻る
-          </Link>
-        </div>
-      )}
-    </main>
+      {/* 全画面Loadingにせず、詳細エリアだけ状態を出し分ける */}
+      <main className="min-h-0 flex-1 overflow-y-auto px-8 lg:pl-0 lg:pr-8">
+        {renderRecipeDetail()}
+      </main>
+    </div>
   );
 }

--- a/src/app/(authenticated)/recipes/[recipeId]/page.tsx
+++ b/src/app/(authenticated)/recipes/[recipeId]/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { errorCodeMap } from '@/lib/constants/errorCodeMap';
 import { idParamSchema } from '@/lib/schema/paramSchema';
 import { recipeDetailSchema, recipeSchema } from '@/lib/schema/recipeSchema';
 import { Loading } from '@authenticated/components/Loading';
@@ -21,7 +22,7 @@ export default function RecipeDetailPage() {
   if (!parsedParams.success) {
     return (
       <main className="px-4">
-        <p>不正なURLです</p>
+        <p>{errorCodeMap.INVALID_ID}</p>
       </main>
     );
   }

--- a/src/app/(authenticated)/recipes/_components/RecipeItem.tsx
+++ b/src/app/(authenticated)/recipes/_components/RecipeItem.tsx
@@ -6,11 +6,34 @@ type Props = {
   recipe: RecipeDetail;
 };
 
+// NOTE: 保存済みレシピの詳細・編集用
 export const RecipeItem = ({ recipe }: Props) => {
   const itemsBlock = stepsItemForParse(recipe.ingredients, recipe.instructions);
 
   return (
     <>
+      <h1 className="mb-2 text-2xl font-bold">{recipe.title}</h1>
+      <p className="mb-2 text-gray-600">
+        ⏱ 調理時間: {recipe.cookingTime || '不明'}
+      </p>
+      <p className="mb-4">{recipe.point}</p>
+      <section>
+        <h2 className="mb-1 text-lg font-semibold">材料（2人分）</h2>
+        <ul className="mb-4 list-inside list-disc">
+          {itemsBlock.ingredients.map((item: string, i: number) => (
+            <li key={i}>{item}</li>
+          ))}
+        </ul>
+
+        <h2 className="mb-1 text-lg font-semibold">作り方</h2>
+        <ol className="list-inside list-decimal">
+          {itemsBlock.instructions.map((step: string, i: number) => (
+            <li key={i} className="mb-1">
+              {step.replace(/^\d+[:：]\s*/, '').trim()}
+            </li>
+          ))}
+        </ol>
+      </section>
       {recipe.imageKey && (
         <Image
           src={`/images/${recipe.imageKey}`}
@@ -20,27 +43,6 @@ export const RecipeItem = ({ recipe }: Props) => {
           className="mb-4 rounded-lg shadow"
         />
       )}
-      <p className="mb-2 text-gray-600">
-        ⏱ 調理時間: {recipe.cookingTime || '不明'}
-      </p>
-      <p className="mb-4">{recipe.point}</p>
-      <section>
-        <h2 className="text-lg font-semibold mb-1">材料（2人分）</h2>
-        <ul className="list-disc list-inside mb-4">
-          {itemsBlock.ingredients.map((item: string, i: number) => (
-            <li key={i}>{item}</li>
-          ))}
-        </ul>
-
-        <h2 className="text-lg font-semibold mb-1">作り方</h2>
-        <ol className="list-decimal list-inside">
-          {itemsBlock.instructions.map((step: string, i: number) => (
-            <li key={i} className="mb-1">
-              {step.replace(/^\d+[:：]\s*/, '').trim()}
-            </li>
-          ))}
-        </ol>
-      </section>
     </>
   );
 };

--- a/src/app/(authenticated)/recipes/page.tsx
+++ b/src/app/(authenticated)/recipes/page.tsx
@@ -2,7 +2,8 @@
 
 import { recipeSummaryListSchema } from '@/lib/schema/recipeSchema';
 import { Loading } from '@authenticated/components/Loading';
-
+import { SideArea } from '@authenticated/components/side/SideArea';
+import { SideNav } from '@authenticated/components/side/SideNav';
 import { useRecipes } from '@authenticated/hooks/useRecipes';
 import { RecipeList } from '@authenticated/recipes/components/RecipeList';
 import Link from 'next/link';
@@ -28,12 +29,29 @@ export default function RecipesPage() {
   }
 
   const renderRecipeList = () => {
-    if (isRecipsLoading || !recipes) {
+    // 初回取得時のみLoadingを表示、再取得中は既存のrecipesを表示
+    if (isRecipsLoading && !recipes) {
       return <Loading />;
     }
 
+    if (!recipes) {
+      // NOTE: 通常はerrorかLoadingに入る想定だが、data未取得の保険として表示
+      return (
+        <>
+          <p>レシピを表示できませんでした</p>
+          <button onClick={() => router.back()}>戻る</button>
+        </>
+      );
+    }
+
     if (recipes.length === 0) {
-      return <p>レシピがまだありません</p>;
+      return (
+        <p>
+          レシピがありません。
+          <br />
+          レシピを作ってみましょう！
+        </p>
+      );
     }
 
     return <RecipeList recipes={recipes} cookingTime={true} />;
@@ -44,20 +62,31 @@ export default function RecipesPage() {
   // TODO: 複数room/共有機能/URL直アクセスに対応する場合、roomIdをURLparamsから取得、API側（/api/talkRoom/[id]）で認可チェックを行う
 
   return (
-    <main className="mx-auto max-w-3xl p-6">
-      <h1 className="mb-6 text-2xl font-bold">あなたのレシピ一覧</h1>
+    <div className="flex h-[calc(100vh-55px)] gap-8">
+      <SideArea>
+        <SideNav />
+      </SideArea>
 
-      {/* 側は出つつ、中身だけ出し分け */}
-      {renderRecipeList()}
+      <main className="min-h-0 flex-1 overflow-y-auto px-8 lg:pl-0 lg:pr-8">
+        <div className="mx-auto max-w-3xl">
+          <h1 className="mb-6 text-2xl font-bold">あなたのレシピ一覧</h1>
 
-      {/* ちらつき防止 */}
-      {talkRoomId && (
-        <div className="mt-6">
-          <Link href={`/talkRoom/${talkRoomId}`} className="text-sm underline">
-            会話に戻る
-          </Link>
+          {/* 全画面Loadingにせず、一覧エリアだけ状態を出し分ける */}
+          {renderRecipeList()}
+
+          {/* ちらつき防止 */}
+          {talkRoomId && (
+            <div className="mt-6">
+              <Link
+                href={`/talkRoom/${talkRoomId}`}
+                className="text-sm underline"
+              >
+                会話に戻る
+              </Link>
+            </div>
+          )}
         </div>
-      )}
-    </main>
+      </main>
+    </div>
   );
 }

--- a/src/app/(authenticated)/talkRoom/[id]/page.tsx
+++ b/src/app/(authenticated)/talkRoom/[id]/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { errorCodeMap } from '@/lib/constants/errorCodeMap';
 import { idParamSchema } from '@/lib/schema/paramSchema';
 import { recipeSchema } from '@/lib/schema/recipeSchema';
 import { useSupabaseSession } from '@auth/hooks/useSupabaseSession';
@@ -37,7 +38,7 @@ export default function TalkRoomIdPage() {
   if (!parsedParams.success) {
     return (
       <main className="px-4">
-        <p>不正なURLです</p>
+        <p>{errorCodeMap.INVALID_ID}</p>
       </main>
     );
   }

--- a/src/app/(authenticated)/talkRoom/[id]/page.tsx
+++ b/src/app/(authenticated)/talkRoom/[id]/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { numberSchema } from '@/lib/schema/numberSchema';
+import { idParamSchema } from '@/lib/schema/paramSchema';
 import { recipeSchema } from '@/lib/schema/recipeSchema';
 import { useSupabaseSession } from '@auth/hooks/useSupabaseSession';
 import { Loading } from '@authenticated/components/Loading';
@@ -26,34 +26,44 @@ export default function TalkRoomIdPage() {
   const [content, setContent] = useState<string>('');
   const [isInputFocused, setIsInputFocused] = useState(false);
   const inputRef = useRef<HTMLDivElement>(null);
-  const { token } = useSupabaseSession();
-  const router = useRouter();
 
+  const { token } = useSupabaseSession();
+
+  const router = useRouter();
   const params = useParams();
-  const parsedParams = numberSchema.safeParse(params.id);
-  if (!parsedParams.success) return <p>不正なURLです</p>;
+
+  const parsedParams = idParamSchema.safeParse(params.id);
+
+  if (!parsedParams.success) {
+    return (
+      <main className="px-4">
+        <p>不正なURLです</p>
+      </main>
+    );
+  }
 
   const talkRoomId = parsedParams.data;
 
-  const url_main = `/api/talks?talkRoomId=${talkRoomId}`;
-  const url_aside = `/api/recipes?take=5`; // TODO: recentRecipesUrlにリネームする
-  const url_suggest = `/api/suggest`;
+  const talkRoomUrl = `/api/talks?talkRoomId=${talkRoomId}`;
+  const recipeListUrl = `/api/recipes?take=5`;
+  const suggestUrl = `/api/suggest`;
 
-  const run = runMutations(mutate, url_main, url_aside);
+  const run = runMutations(mutate, talkRoomUrl, recipeListUrl);
 
   const {
     data: talks,
     error: talkError,
     isLoading: isTalkLoading,
-  } = useTalks(url_main);
+  } = useTalks(talkRoomUrl);
 
+  // sidenav用レシピ一覧
   const {
     data: recipes,
-    error: recipeError,
-    isLoading: isRecipeLoading,
-  } = useRecipes(url_aside, recipeSchema);
+    error: recipesError,
+    isLoading: isRecipesLoading,
+  } = useRecipes(recipeListUrl, recipeSchema); // レシピ一覧・レシピ詳細でschemaが異なるため、呼び出し側でschemaを渡す
 
-  const { suggest } = useSuggest({ url_suggest, isInputFocused });
+  const { suggest } = useSuggest({ suggestUrl, isInputFocused }); // サジェスト取得条件をまとめて渡す
 
   const handleInputFocus = () => {
     setIsInputFocused(true);
@@ -99,10 +109,10 @@ export default function TalkRoomIdPage() {
     );
   }
 
-  if (recipeError) {
+  if (recipesError) {
     return (
       <div>
-        <p>{recipeError}</p>
+        <p>{recipesError}</p>
         <button onClick={() => router.back()}>戻る</button>
         <Link href="/">TOPに戻る</Link>
       </div>

--- a/src/app/(authenticated)/talkRoom/_components/talks/TalkChef.tsx
+++ b/src/app/(authenticated)/talkRoom/_components/talks/TalkChef.tsx
@@ -1,4 +1,4 @@
-import { TalkSurface } from '@authenticated/talkRoom/components/talks/TalkSurface';
+import { Surface } from '../../../../../components/ui/Surface';
 
 type Props = {
   content: string;
@@ -6,8 +6,8 @@ type Props = {
 
 export const TalkChef = ({ content }: Props) => {
   return (
-    <TalkSurface type="chef">
+    <Surface type="chef">
       <p className="whitespace-pre-line">{content}</p>
-    </TalkSurface>
+    </Surface>
   );
 };

--- a/src/app/(authenticated)/talkRoom/_components/talks/TalkRecipe.tsx
+++ b/src/app/(authenticated)/talkRoom/_components/talks/TalkRecipe.tsx
@@ -4,7 +4,7 @@ import { Surface } from '../../../../../components/ui/Surface';
 type Props = {
   recipe: RecipeObj;
 };
-
+// NOTE: トーク内の読み取り専用
 // TODO: RecipeDetail実装時に、材料・作り方などの内部表示を共通パーツとして抽出する。
 export const TalkRecipe = ({ recipe }: Props) => {
   return (

--- a/src/app/(authenticated)/talkRoom/_components/talks/TalkRecipe.tsx
+++ b/src/app/(authenticated)/talkRoom/_components/talks/TalkRecipe.tsx
@@ -1,5 +1,5 @@
 import type { RecipeObj } from '@/lib/schema/recipeBlockSchema';
-import { TalkSurface } from '@authenticated/talkRoom/components/talks/TalkSurface';
+import { Surface } from '../../../../../components/ui/Surface';
 
 type Props = {
   recipe: RecipeObj;
@@ -8,7 +8,7 @@ type Props = {
 // TODO: RecipeDetail実装時に、材料・作り方などの内部表示を共通パーツとして抽出する。
 export const TalkRecipe = ({ recipe }: Props) => {
   return (
-    <TalkSurface type="recipe">
+    <Surface type="recipe">
       <h2 className="mb-1 text-[18px] font-[600]">
         {recipe['レシピタイトル']}
       </h2>
@@ -52,6 +52,6 @@ export const TalkRecipe = ({ recipe }: Props) => {
           ))}
         </ol>
       </div>
-    </TalkSurface>
+    </Surface>
   );
 };

--- a/src/app/(authenticated)/talkRoom/_components/talks/TalkUser.tsx
+++ b/src/app/(authenticated)/talkRoom/_components/talks/TalkUser.tsx
@@ -1,14 +1,14 @@
-import { TalkSurface } from '@authenticated/talkRoom/components/talks/TalkSurface';
+import { Surface } from '../../../../../components/ui/Surface';
 
 type Props = {
   content: string;
 };
 
-// contentをTalkSurfaceのchildrenとして渡す薄いラッパー
+// contentをSurfaceのchildrenとして渡す薄いラッパー
 export const TalkUser = ({ content }: Props) => {
   return (
-    <TalkSurface type="user">
+    <Surface type="user">
       <p className="whitespace-pre-line">{content}</p>
-    </TalkSurface>
+    </Surface>
   );
 };

--- a/src/app/(authenticated)/talkRoom/_hooks/useSuggest.ts
+++ b/src/app/(authenticated)/talkRoom/_hooks/useSuggest.ts
@@ -2,13 +2,13 @@ import { suggestCollectionSchema } from '@/lib/schema/suggestSchema';
 import { useAuthedSWR } from '@authenticated/hooks/useAuthedSWR';
 
 type UseSuggestArgs = {
-  url_suggest: string;
+  suggestUrl: string;
   isInputFocused: boolean;
 };
 
 // サジェストデータの取得実行、取得タイミングの制御をするフック
-export const useSuggest = ({ url_suggest, isInputFocused }: UseSuggestArgs) => {
-  const swrKey = isInputFocused ? url_suggest : null;
+export const useSuggest = ({ suggestUrl, isInputFocused }: UseSuggestArgs) => {
+  const swrKey = isInputFocused ? suggestUrl : null;
   // NOTE: suggestは初回フォーカス時のみ取得、その後はキャッシュ利用
 
   const { data: suggest } = useAuthedSWR(swrKey, suggestCollectionSchema);

--- a/src/app/api/recipes/[id]/route.ts
+++ b/src/app/api/recipes/[id]/route.ts
@@ -1,6 +1,6 @@
 import { createErrorResponse } from '@/lib/apiServer/createErrorResponse';
 import { requireUserId } from '@/lib/apiServer/requireUserId';
-import { numberSchema } from '@/lib/schema/numberSchema';
+import { idParamSchema } from '@/lib/schema/paramSchema';
 import { prisma } from '@/lib/utils/prisma';
 import { NextRequest, NextResponse } from 'next/server';
 import { ZodError } from 'zod';
@@ -15,7 +15,7 @@ export async function GET(
       return createErrorResponse('UNAUTHORIZED', 401);
     }
 
-    const recipeId = numberSchema.parse(params.id);
+    const recipeId = idParamSchema.parse(params.id);
 
     const recipe = await prisma.recipe.findFirst({
       where: { id: recipeId, createdByUser: userId },
@@ -39,7 +39,7 @@ export async function GET(
   } catch (e) {
     if (e instanceof ZodError) {
       console.error('[Recipe API] GET Validation failed', e);
-      return createErrorResponse('INVALID_FORMAT', 400);
+      return createErrorResponse('INVALID_ID', 400);
     }
     console.error('[Recipe API] GET Unexpected error', e);
     return createErrorResponse('INTERNAL_SERVER_ERROR', 500);

--- a/src/app/api/recipes/route.ts
+++ b/src/app/api/recipes/route.ts
@@ -28,7 +28,7 @@ export async function GET(request: NextRequest) {
       take,
     });
 
-    return NextResponse.json(recipes); // 0件でも正常（空配列で返す）
+    return NextResponse.json(recipes); // 0件(データ未保存）でも正常（空配列で返す）
   } catch (e) {
     if (e instanceof ZodError) {
       console.error('[Recipes API] GET Validation failed', e);

--- a/src/components/ui/Icon.tsx
+++ b/src/components/ui/Icon.tsx
@@ -8,7 +8,7 @@ type Props = {
   className?: string;
 };
 
-export const NavImage = ({ src, width, height, className }: Props) => {
+export const Icon = ({ src, width, height, className }: Props) => {
   return (
     <Image
       src={src}

--- a/src/components/ui/Surface.tsx
+++ b/src/components/ui/Surface.tsx
@@ -5,7 +5,7 @@ import { createShadow } from '@styles/tailwindTokens';
 type SurfaceType = keyof typeof surfaceStyles;
 type Props = {
   type: SurfaceType;
-  children: React.ReactNode;
+  children?: React.ReactNode;
 };
 
 // NOTE: typeごとの差分を閉じるためTailwindクラスをconfigに置く。
@@ -35,12 +35,20 @@ const surfaceStyles = {
       highlight: primitives.gray.dove,
     }),
   },
+  'recipe-detail': {
+    shape: 'mx-auto w-full',
+    background: 'bg-beige-tomato',
+    shadow: createShadow('hard', {
+      base: primitives.gray.dark,
+      highlight: primitives.gray.dove,
+    }),
+  },
 } as const;
 
 const baseClassName = 'mb-6 rounded-xl px-4 pb-4 pt-3';
 
-// トーク外枠だけを提供し、中身の種類は関知しない
-export const TalkSurface = ({ type, children }: Props) => {
+// 外枠だけを提供
+export const Surface = ({ type, children }: Props) => {
   // typeごとの箱の差分
   const config = surfaceStyles[type];
 

--- a/src/lib/constants/errorCodeMap.ts
+++ b/src/lib/constants/errorCodeMap.ts
@@ -1,7 +1,10 @@
 import { ErrorCode } from '@/lib/schema/errorSchema';
 
+// アプリ独自
 export const errorCodeMap: Record<ErrorCode, string> = {
-  INVALID_FORMAT: '料理名や食材を教えてください',
+  //INVALID_FORMAT: '料理名や食材を教えてください', TODO: 料理名・食材入力の不足は専用errorCodeへ切り出す
+  INVALID_FORMAT: '入力内容を確認してください',
+  INVALID_ID: '不正なURLです',
   UNAUTHORIZED: 'ログインが必要です',
   FORBIDDEN: '現在この機能は利用できません。設定をご確認ください',
   TALK_NOT_FOUND: 'トークが見つかりません',

--- a/src/lib/constants/errorCodeMap.ts
+++ b/src/lib/constants/errorCodeMap.ts
@@ -1,6 +1,6 @@
 import { ErrorCode } from '@/lib/schema/errorSchema';
 
-// アプリ独自
+// APIから返るアプリ独自errorCodeを、UI表示用メッセージに変換
 export const errorCodeMap: Record<ErrorCode, string> = {
   //INVALID_FORMAT: '料理名や食材を教えてください', TODO: 料理名・食材入力の不足は専用errorCodeへ切り出す
   INVALID_FORMAT: '入力内容を確認してください',

--- a/src/lib/schema/errorSchema.ts
+++ b/src/lib/schema/errorSchema.ts
@@ -6,6 +6,7 @@ import z from 'zod';
 // ④ サーバー・その他
 export const errorCodeSchema = z.enum([
   'INVALID_FORMAT',
+  'INVALID_ID',
   'UNAUTHORIZED',
   'FORBIDDEN',
   'TALK_NOT_FOUND',

--- a/src/lib/schema/paramSchema.ts
+++ b/src/lib/schema/paramSchema.ts
@@ -1,0 +1,4 @@
+import z from 'zod';
+
+// URLparamsの検証用
+export const idParamSchema = z.string().regex(/^\d+$/).transform(Number);


### PR DESCRIPTION
## 実装内容

- URL params用のIDschemaを追加
- Surfaceを共通UIコンポーネントへ移動
- レシピ詳細画面にSurfaceを追加
- レシピ詳細・一覧画面にSideArea / SideNavを適用
- レシピ詳細・一覧画面の表示分岐を整理
- レシピ詳細画面のスクロール領域を調整

ボタン化など細かいUI調整は後続PRで対応予定です。